### PR TITLE
Updated driver to v1.0.0 which required net8

### DIFF
--- a/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
+++ b/src/Tests/ApprovalFiles/NoPublicApiChanges.Run.approved.cs
@@ -1,5 +1,5 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/DbUp/dbup-clickhouse.git")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName=".NET Standard 2.1")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace DbUp.ClickHouse
 {
     public class ClickHouseConnectionManager : DbUp.Engine.Transactions.DatabaseConnectionManager

--- a/src/Tests/ClickHouseContainerFixture.cs
+++ b/src/Tests/ClickHouseContainerFixture.cs
@@ -1,4 +1,4 @@
-﻿using Testcontainers.ClickHouse;
+using Testcontainers.ClickHouse;
 using Xunit;
 
 namespace DbUp.ClickHouse.Tests;
@@ -15,7 +15,7 @@ public class ClickHouseContainerFixture : IAsyncLifetime
     public async Task InitializeAsync()
     {
         // Create and start a ClickHouse container
-        var container = new ClickHouseBuilder().WithDatabase("testdb")
+        var container = new ClickHouseBuilder("clickhouse/clickhouse-server:latest").WithDatabase("testdb")
             .Build();
 
         await container.StartAsync();

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -9,11 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClickHouse.Driver" Version="0.7.20" />
     <ProjectReference Include="..\dbup-clickhouse\dbup-clickhouse.csproj" />
-    <PackageReference Include="DbUp.Tests.Common" Version="6.0.15" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="Testcontainers.ClickHouse" Version="4.8.1" />
+    <PackageReference Include="DbUp.Tests.Common" Version="6.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Testcontainers.ClickHouse" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/dbup-clickhouse/dbup-clickhouse.csproj
+++ b/src/dbup-clickhouse/dbup-clickhouse.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>DbUp makes it easy to deploy and upgrade databases. This package adds ClickHouse support.</Description>
@@ -6,7 +6,7 @@
     <Company>DbUp Contributors</Company>
     <Product>DbUp</Product>
     <Copyright>Copyright © DbUp Contributors 2015</Copyright>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFramework>net8</TargetFramework>
     <AssemblyName>dbup-clickhouse</AssemblyName>
     <RootNamespace>DbUp.ClickHouse</RootNamespace>
     <PackageId>dbup-clickhouse</PackageId>
@@ -23,8 +23,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="ClickHouse.Driver" Version="0.7.20" />
-    <PackageReference Include="dbup-core" Version="6.0.15" />
+    <PackageReference Include="ClickHouse.Driver" Version="1.0.0" />
+    <PackageReference Include="dbup-core" Version="6.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[Clickhouse.Driver 1.0.0](https://github.com/ClickHouse/clickhouse-cs/releases/tag/1.0.0) was released. They [dropped support](https://github.com/ClickHouse/clickhouse-cs/releases/tag/1.0.0) for netstandard and netfx, so we will too as we want to stay up to date with dependencies.

**Platform and Framework Updates:**
* Changed the target framework of the main project from `netstandard2.1;net462` to `net8`, and updated the test project to target `.NET 8.0` as well. [[1]](diffhunk://#diff-ac2e881acac4bbe9272534eb21831ca8dc2f8f07a571dd716e5726edce93bd6bL1-R9) [[2]](diffhunk://#diff-f12901a5c86120379a005cbfccc4dba469d60f4c5a4901b641658103ae972d86L2-R2)

**Dependency Updates:**
* Upgraded `ClickHouse.Driver` to version `1.0.0` and `dbup-core` to `6.1.1` in the main project.
* Updated test dependencies: `DbUp.Tests.Common` to `6.1.1`, `Microsoft.NET.Test.Sdk` to `18.0.1`, and `Testcontainers.ClickHouse` to `4.10.0`. Removed the unused `ClickHouse.Driver` reference from the test project.

**Test Container Improvements:**
* Modified the ClickHouse test container setup to explicitly use the `clickhouse/clickhouse-server:latest` image, ensuring consistent test environments.